### PR TITLE
Fix incorrect saving during SortCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SortCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortCommand.java
@@ -49,6 +49,7 @@ public class SortCommand extends Command {
             return new CommandResult(MESSAGE_NO_PERSONS);
         }
 
+
         Comparator<Person> comparator;
         switch (sortByKeyword) {
         case "deadline":

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -143,13 +143,25 @@ public class ModelManager implements Model {
     @Override
     public void sortByComparator(Comparator<Person> comparator) {
         currentComparator = comparator;
-        int initialSize = sortedPersons.size();
+
+        // Initial size of the addressBook with all contacts
+        int initialSize = addressBook.getPersonList().size();
+
+        //Initial size of filtered persons i.e if a FindCommand has been executed
+        int initialSortedSize = sortedPersons.size();
+
         sortedPersons.setComparator(comparator);
 
-        // Assert that sortedPersons size remains same after sorting
-        assert sortedPersons.size() == initialSize;
+        SortedList<Person> sortedAllPersons = new SortedList<>(this.addressBook.getPersonList());
+        sortedAllPersons.setComparator(comparator);
 
-        addressBook.setPersons(sortedPersons);
+        // Assert that sortedPersons size remains same after sorting
+        assert sortedPersons.size() == initialSortedSize;
+
+        // Assert that no contacts get deleted during the sort command
+        assert sortedAllPersons.size() == addressBook.getPersonList().size();
+
+        addressBook.setPersons(sortedAllPersons);
     }
 
     //=========== Reminder Manager ==========================================================================

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -155,11 +155,9 @@ public class ModelManager implements Model {
         SortedList<Person> sortedAllPersons = new SortedList<>(this.addressBook.getPersonList());
         sortedAllPersons.setComparator(comparator);
 
-        // Assert that sortedPersons size remains same after sorting
+        // Assert that sizes remains same after sorting
+        assert sortedAllPersons.size() == initialSize;
         assert sortedPersons.size() == initialSortedSize;
-
-        // Assert that no contacts get deleted during the sort command
-        assert sortedAllPersons.size() == addressBook.getPersonList().size();
 
         addressBook.setPersons(sortedAllPersons);
     }

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -114,6 +114,38 @@ public class ModelManagerTest {
     }
 
     @Test
+    public void sortByComparator_afterFindCommand_doesNotDeleteContacts() {
+        // Add multiple contacts
+        modelManager.addPerson(GEORGE);
+        modelManager.addPerson(ALICE);
+        modelManager.addPerson(BENSON);
+
+        // Apply a filter to show only contacts with "George" in the name
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("George"));
+        modelManager.updateFilteredPersonList(predicate);
+
+        // Check that the filtered list contains only GEORGE
+        assertEquals(1, modelManager.getFilteredPersonList().size());
+        assertTrue(modelManager.getFilteredPersonList().contains(GEORGE));
+
+        // Sort the list by name
+        Comparator<Person> comparatorByName = Comparator.comparing(person -> person.getName().fullName);
+        modelManager.sortByComparator(comparatorByName);
+
+        // After sorting, ensure all contacts are still in the address book
+        AddressBook expectedAddressBook = new AddressBookBuilder()
+                .withPerson(ALICE)
+                .withPerson(BENSON)
+                .withPerson(GEORGE)
+                .build();
+        assertEquals(expectedAddressBook, modelManager.getAddressBook());
+
+        // Restore the full person list after the sorting
+        modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        assertEquals(3, modelManager.getFilteredPersonList().size()); // Ensure no persons were deleted
+    }
+
+    @Test
     public void equals() {
         AddressBook addressBook = new AddressBookBuilder().withPerson(ALICE).withPerson(BENSON).build();
         AddressBook differentAddressBook = new AddressBook();


### PR DESCRIPTION
During the SortCommand, if a FindCommand was executed first, which reduces the size of the sortedPersons list, then during the save, contacts not matching the find query get deleted. 

To fix this:

- Updated the ModelManager to sort the sortedPersons and sort every contact
- Then, the ModelManager only saves the sortedAllPersons instead of the sortedPersons.

Closes #148 