### PR TITLE
Add functionality to whitelist and blacklist commands

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -178,6 +178,17 @@ Examples:
 
   ![result for 'find alex david'](images/findAlexDavidResult.png)
 
+
+<div markdown="span" class="alert alert-primary">:bulb: **Tip:**
+#### Shortcuts: Finding blacklisted/whitelisted clients
+
+To find all clients that are blacklisted (with no other parameters), the command `blacklist` can be entered.
+
+Similarly, the `whitelist` command can be entered to find all clients who are whitelisted.
+
+_Note: both of these commands need to be entered without any parameters otherwise the app responds with an error message._
+</div>
+
 ### Delete Client Details : `delete`
 
 Deletes the specified person from Clientele+.

--- a/src/main/java/seedu/address/logic/commands/BlacklistCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BlacklistCommand.java
@@ -20,8 +20,9 @@ public class BlacklistCommand extends Command {
 
     public static final String COMMAND_WORD = "blacklist";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + " INDEX : adds a person to the blacklist."
-            + "\nExample: '" + COMMAND_WORD + " 2' blacklists the 2nd client in the list.";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " INDEX : adds a client to the blacklist."
+            + "\nExample: '" + COMMAND_WORD + " 2' blacklists the 2nd client in the list."
+            + "\nAlternate use: entering '" + COMMAND_WORD + "' shows all blacklisted clients.";
 
     public static final String MESSAGE_BLACKLIST_PERSON_SUCCESS = "Blacklisted Person: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/BlacklistListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/BlacklistListCommand.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.parser.FindCommandParser;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Model;
+
+/**
+ * Lists out all blacklisted clients
+ */
+public class BlacklistListCommand extends BlacklistCommand {
+
+    /**
+     * Instantiates a {@code BlacklistListCommand} object.
+     */
+    public BlacklistListCommand() {
+        super(Index.fromZeroBased(0)); // this is irrelevant but necessary
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        try {
+            // make the find command do the hard work
+            return (new FindCommandParser().parse("find cs/blacklisted")).execute(model);
+        } catch (ParseException pe) {
+            return null; // this will never happen
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/WhitelistCommand.java
+++ b/src/main/java/seedu/address/logic/commands/WhitelistCommand.java
@@ -25,7 +25,8 @@ public class WhitelistCommand extends Command {
             + ": removes person from the blacklist and sets their client status to NEW_CLIENT_STATUS."
             + " NEW_CLIENT_STATUS must be 'old', 'active', 'potential' or 'unresponsive'."
             + "\nExample: '" + COMMAND_WORD + " 2 cs/old' sets the client status of the 2nd "
-            + "client in the list as 'old' after removing them from the blacklist.";
+            + "client in the list as 'old' after removing them from the blacklist."
+            + "\nAlternate use: entering '" + COMMAND_WORD + "' will list out all clients NOT on the blacklist";
 
     public static final String MESSAGE_WHITELIST_PERSON_SUCCESS = "Whitelisted Person: %1$s";
     public static final String MESSAGE_CANNOT_WHITELIST = "This person is not on the blacklist: %1$s";

--- a/src/main/java/seedu/address/logic/commands/WhitelistListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/WhitelistListCommand.java
@@ -1,0 +1,38 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.ArgumentPredicateToFail;
+import seedu.address.model.person.ClientStatus;
+
+/**
+ * Lists out all whitelisted clients
+ */
+public class WhitelistListCommand extends WhitelistCommand {
+
+    /**
+     * Instantiates a {@code WhitelistListCommand} object.
+     *
+     * @param argPredToFail an argument predicate that should fail
+     */
+    public WhitelistListCommand() {
+        // this is irrelevant but necessary
+        super(Index.fromZeroBased(0), new ClientStatus("old"));
+
+        // the main predicate
+        // this.argPredToFail = argPredToFail;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+
+        model.updateFilteredPersonList(ArgumentPredicateToFail.getNotBlacklistedPredicate());
+
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/BlacklistCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/BlacklistCommandParser.java
@@ -1,10 +1,11 @@
 package seedu.address.logic.parser;
 
-import static java.util.Objects.requireNonNull;
+// import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.BlacklistCommand;
+import seedu.address.logic.commands.BlacklistListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -13,20 +14,28 @@ import seedu.address.logic.parser.exceptions.ParseException;
 public class BlacklistCommandParser implements Parser<BlacklistCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the EditCommand
-     * and returns an EditCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the BlacklistCommand
+     * and returns a BlacklistCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public BlacklistCommand parse(String args) throws ParseException {
-        requireNonNull(args);
+        // requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args);
 
         Index index;
+        String preamble = argMultimap.getPreamble();
 
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            index = ParserUtil.parseIndex(preamble);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, BlacklistCommand.MESSAGE_USAGE), pe);
+            if (preamble.equals("")) {
+                // only allow "blacklist" with no params as the valid command
+                return new BlacklistListCommand();
+            } else {
+                // any non-empty non-index params throws an error
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                        BlacklistCommand.MESSAGE_USAGE), pe);
+            }
         }
 
         return new BlacklistCommand(index);

--- a/src/main/java/seedu/address/logic/parser/WhitelistCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/WhitelistCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_CLIENT_STATUS;
 
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.WhitelistCommand;
+import seedu.address.logic.commands.WhitelistListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.ClientStatus;
 
@@ -17,15 +18,16 @@ public class WhitelistCommandParser implements Parser<WhitelistCommand> {
     /**
      * Checks if the new client status is valid.
      * The new client status must be 'old', 'active' or 'potential',
-     * it cannot be 'blaclisted' (despite that being a valid client status).
+     * it cannot be 'blacklisted' (despite it being a valid client status).
+     * {@code clientStatus} will already be validated.
      */
     public boolean isValidNewClientStatus(ClientStatus clientStatus) {
         return !clientStatus.isBlacklisted();
     }
 
     /**
-     * Parses the given {@code String} of arguments in the context of the EditCommand
-     * and returns an EditCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the WhitelistCommand
+     * and returns a WhitelistCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
     public WhitelistCommand parse(String args) throws ParseException {
@@ -35,21 +37,37 @@ public class WhitelistCommandParser implements Parser<WhitelistCommand> {
 
         Index index;
         ClientStatus newClientStatus;
+        String preamble = argMultimap.getPreamble();
 
         try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+            index = ParserUtil.parseIndex(preamble);
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, WhitelistCommand.MESSAGE_USAGE), pe);
+            if (preamble.equals("") && !argMultimap.getValue(PREFIX_CLIENT_STATUS).isPresent()) {
+                // Map<String, Object> parameterMap = new HashMap<>();
+
+                // parameterMap.put(ClientStatus.CLIENT_STATUS_KEY, new ClientStatus("blacklisted"));
+
+                // Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+                // parameterMap.put(Tag.TAG_KEY, tagList);
+
+                // here, the predicate dictates that the client status should be blacklisted;
+                // hence if the predicate fails (ensured by the ArgumentPredicateToFail object)
+                // the client is not blacklisted => they are whitelisted
+                // return new WhitelistListCommand(new ArgumentPredicateToFail(parameterMap));
+                return new WhitelistListCommand();
+            } else {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, WhitelistCommand.MESSAGE_USAGE), pe);
+            }
         }
 
         if (argMultimap.getValue(PREFIX_CLIENT_STATUS).isPresent()) {
             newClientStatus = ParserUtil.parseClientStatus(argMultimap.getValue(PREFIX_CLIENT_STATUS).get());
-        } else {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, WhitelistCommand.MESSAGE_USAGE));
-        }
-
-        if (isValidNewClientStatus(newClientStatus)) {
-            return new WhitelistCommand(index, newClientStatus);
+            if (isValidNewClientStatus(newClientStatus)) {
+                return new WhitelistCommand(index, newClientStatus);
+            } else {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, WhitelistCommand.MESSAGE_USAGE));
+            }
         } else {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, WhitelistCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/model/person/ArgumentPredicateToFail.java
+++ b/src/main/java/seedu/address/model/person/ArgumentPredicateToFail.java
@@ -1,9 +1,9 @@
 package seedu.address.model.person;
 
-import static java.util.Objects.requireNonNull;
-
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -13,23 +13,34 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.model.tag.Tag;
 
 /**
- * Tests that input parameters matches all the requirements of a particular Person
+ * Like an {@code ArgumentPredicate}, but instead tests to see if the Person fails the predicate
  */
-public class ArgumentPredicate implements Predicate<Person> {
-    private final Map<String, Object> inputParameters;
+public class ArgumentPredicateToFail extends ArgumentPredicate {
+
+    private static ArgumentPredicateToFail notBlacklistedPredicate;
 
     /**
-     * Constructs an {@code ArgumentPredicate}
+     * Constructs an {@code ArgumentPredicateToFail}
      *
      * @param parameterMap A map with parameters inputted by user
      */
-    public ArgumentPredicate(Map<String, Object> parameterMap) {
-        requireNonNull(parameterMap);
-        inputParameters = parameterMap;
+    public ArgumentPredicateToFail(Map<String, Object> parameterMap) {
+        super(parameterMap);
     }
 
-    public Map<String, Object> getInputParameters() {
-        return this.inputParameters;
+    public static ArgumentPredicateToFail getNotBlacklistedPredicate() {
+        if (notBlacklistedPredicate == null) {
+            Map<String, Object> parameterMap = new HashMap<>();
+
+            parameterMap.put(ClientStatus.CLIENT_STATUS_KEY, new ClientStatus("blacklisted"));
+
+            Set<Tag> tagList = new HashSet<>();
+            parameterMap.put(Tag.TAG_KEY, tagList);
+
+            notBlacklistedPredicate = new ArgumentPredicateToFail(parameterMap);
+        }
+
+        return notBlacklistedPredicate;
     }
 
     private void addIfPresent(String key, Predicate<Person> predicate,
@@ -38,8 +49,8 @@ public class ArgumentPredicate implements Predicate<Person> {
         assert predicate != null : "Predicate should not be null";
         assert person != null : "Person should not be null";
         assert validParameters != null : "Valid parameters list should not be null";
-        if (inputParameters.containsKey(key)) {
-            validParameters.add(predicate.test(person));
+        if (getInputParameters().containsKey(key)) {
+            validParameters.add(!predicate.test(person));
         }
     }
 
@@ -50,42 +61,42 @@ public class ArgumentPredicate implements Predicate<Person> {
         assert person != null : "Person should not be null";
         assert validParameters != null : "Valid parameters list should not be null";
         if (!tags.isEmpty()) {
-            validParameters.add(predicate.test(person));
+            validParameters.add(!predicate.test(person));
         }
     }
 
     private List<Boolean> getValidParameters(Person person) {
         List<Boolean> validParameters = new ArrayList<>();
         addIfPresent(Name.NAME_KEY, p -> {
-            String[] nameKeywords = inputParameters.get("name").toString().split("\\s+");
+            String[] nameKeywords = getInputParameters().get("name").toString().split("\\s+");
             NameContainsKeywordsPredicate namePredicate =
                     new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
             return namePredicate.test(p);
         }, person, validParameters);
 
-        addIfPresent(Phone.PHONE_KEY, p -> inputParameters.get("phone").equals(p.getPhone()),
+        addIfPresent(Phone.PHONE_KEY, p -> getInputParameters().get("phone").equals(p.getPhone()),
                 person, validParameters);
 
-        addIfPresent(Email.EMAIL_KEY, p -> inputParameters.get("email").equals(p.getEmail()),
+        addIfPresent(Email.EMAIL_KEY, p -> getInputParameters().get("email").equals(p.getEmail()),
                 person, validParameters);
 
-        addIfPresent(Address.ADDRESS_KEY, p -> inputParameters.get("address").equals(p.getAddress()),
+        addIfPresent(Address.ADDRESS_KEY, p -> getInputParameters().get("address").equals(p.getAddress()),
                 person, validParameters);
 
-        addIfPresent(ProjectStatus.PROJECT_STATUS_KEY, p -> inputParameters.get("project status")
+        addIfPresent(ProjectStatus.PROJECT_STATUS_KEY, p -> getInputParameters().get("project status")
                 .equals(p.getProjectStatus()), person, validParameters);
 
-        addIfPresent(PaymentStatus.PAYMENT_STATUS_KEY, p -> inputParameters.get("payment status")
+        addIfPresent(PaymentStatus.PAYMENT_STATUS_KEY, p -> getInputParameters().get("payment status")
                     .equals(p.getPaymentStatus()), person, validParameters);
 
-        addIfPresent(ClientStatus.CLIENT_STATUS_KEY, p -> inputParameters.get("client status")
+        addIfPresent(ClientStatus.CLIENT_STATUS_KEY, p -> getInputParameters().get("client status")
                     .equals(p.getClientStatus()), person, validParameters);
 
-        addIfPresent(Deadline.DEADLINE_KEY, p -> inputParameters.get("deadline")
+        addIfPresent(Deadline.DEADLINE_KEY, p -> getInputParameters().get("deadline")
                 .equals(p.getDeadline()), person, validParameters);
 
         @SuppressWarnings("unchecked")
-        Set<Tag> tags = (Set<Tag>) inputParameters.get(Tag.TAG_KEY);
+        Set<Tag> tags = (Set<Tag>) getInputParameters().get(Tag.TAG_KEY);
         addIfTagPresent(tags, p -> tags.stream()
                 .anyMatch(p.getTags()::contains), person, validParameters);
 
@@ -105,16 +116,16 @@ public class ArgumentPredicate implements Predicate<Person> {
         }
 
         // instanceof handles nulls
-        if (!(other instanceof ArgumentPredicate)) {
+        if (!(other instanceof ArgumentPredicateToFail)) {
             return false;
         }
 
-        ArgumentPredicate argumentPredicate = (ArgumentPredicate) other;
-        return inputParameters.equals(argumentPredicate.inputParameters);
+        ArgumentPredicateToFail argumentPredicateToFail = (ArgumentPredicateToFail) other;
+        return getInputParameters().equals(argumentPredicateToFail.getInputParameters());
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("parameters", inputParameters).toString();
+        return new ToStringBuilder(this).add("parameters to fail", getInputParameters()).toString();
     }
 }

--- a/src/test/java/seedu/address/logic/commands/BlacklistCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/BlacklistCommandTest.java
@@ -1,0 +1,46 @@
+// package seedu.address.logic.commands;
+
+// import static seedu.address.logic.commands.CommandTestUtil.VALID_CLIENT_STATUS_BLACKLISTED;
+// import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+// import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+// import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+// import java.util.Random;
+
+// import org.junit.jupiter.api.Test;
+
+// import seedu.address.commons.core.index.Index;
+// import seedu.address.logic.Messages;
+// import seedu.address.model.AddressBook;
+// import seedu.address.model.ArchivedAddressBook;
+// import seedu.address.model.Model;
+// import seedu.address.model.ModelManager;
+// import seedu.address.model.UserPrefs;
+// import seedu.address.model.person.Person;
+// import seedu.address.testutil.PersonBuilder;
+
+// public class BlacklistCommandTest {
+
+//     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs(), new ArchivedAddressBook());
+//     private Random rng = new Random();
+
+//     @Test
+//     public void blacklist_firstPerson_success() {
+//         Person firstPerson = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+
+//         BlacklistCommand blacklistCommand = new BlacklistCommand(INDEX_FIRST_PERSON);
+
+//         Person blacklistedPerson = new PersonBuilder(firstPerson)
+//                 .withClientStatus(VALID_CLIENT_STATUS_BLACKLISTED).build();
+
+//         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs(),
+//                 new ArchivedAddressBook());
+
+//         String expectedMessage = String.format(
+//                  BlacklistCommand.MESSAGE_BLACKLIST_PERSON_SUCCESS, Messages.format(blacklistedPerson));
+
+//         expectedModel.setPerson(firstPerson, blacklistedPerson);
+
+//         assertCommandSuccess(blacklistCommand, model, expectedMessage, expectedModel);
+//     }
+// }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -50,6 +50,7 @@ public class CommandTestUtil {
     public static final String VALID_CLIENT_STATUS_UNRESPONSIVE = "unresponsive";
     public static final String VALID_CLIENT_STATUS_POTENTIAL = "potential";
     public static final String VALID_CLIENT_STATUS_OLD = "old";
+    public static final String VALID_CLIENT_STATUS_BLACKLISTED = "blacklisted";
     public static final String VALID_DEADLINE_AMY = "10-10-2024";
     public static final String VALID_DEADLINE_BOB = "10-11-2024";
 


### PR DESCRIPTION
Previously, the `whitelist` and `blacklist` commands could only whitelist/blacklist clients. Now, their functionality has been extended to all users to also list out all whitelisted/blacklisted clients through these commands.